### PR TITLE
Horner's rule benchmarks show that this step should be done in the CPU

### DIFF
--- a/src/submission/horners_rule_benchmark.ts
+++ b/src/submission/horners_rule_benchmark.ts
@@ -1,0 +1,147 @@
+import assert from 'assert'
+import mustache from 'mustache'
+import { ExtPointType } from "@noble/curves/abstract/edwards";
+import { BigIntPoint } from "../reference/types"
+import { FieldMath } from "../reference/utils/FieldMath";
+import {
+    get_device,
+    create_and_write_sb,
+    create_bind_group,
+    create_bind_group_layout,
+    create_compute_pipeline,
+    create_sb,
+    read_from_gpu,
+    execute_pipeline,
+} from './gpu'
+import structs from './wgsl/struct/structs.template.wgsl'
+import bigint_funcs from './wgsl/bigint/bigint.template.wgsl'
+import field_funcs from './wgsl/field/field.template.wgsl'
+import ec_funcs from './wgsl/curve/ec.template.wgsl'
+import curve_parameters from './wgsl/curve/parameters.template.wgsl'
+import montgomery_product_funcs from './wgsl/montgomery/mont_pro_product.template.wgsl'
+import bucket_points_reduction_shader from './wgsl/bucket_points_reduction_shader.template.wgsl'
+import horners_rule_shader from './wgsl/horners_rule.template.wgsl'
+import { are_point_arr_equal, compute_misc_params, u8s_to_bigints, numbers_to_u8s_for_gpu, gen_p_limbs, bigints_to_u8_for_gpu } from './utils'
+
+export const horners_rule_benchmark = async (
+    baseAffinePoints: BigIntPoint[],
+    scalars: bigint[]
+): Promise<{x: bigint, y: bigint}> => {
+    const fieldMath = new FieldMath()
+    const p = BigInt('0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001')
+    const word_size = 13
+    const chunk_size = 16
+    const params = compute_misc_params(p, word_size)
+    const n0 = params.n0
+    const num_words = params.num_words
+    const r = params.r
+    const rinv = params.rinv
+    const p_limbs = gen_p_limbs(p, num_words, word_size)
+
+    const num_subtasks = 16
+    assert(baseAffinePoints.length >= num_subtasks)
+
+    // Take the first num_subtasks points
+    const x_y_coords: bigint[] = []
+    const t_z_coords: bigint[] = []
+    for (const pt of baseAffinePoints.slice(0, num_subtasks)) {
+        x_y_coords.push(fieldMath.Fp.mul(pt.x, r))
+        x_y_coords.push(fieldMath.Fp.mul(pt.y, r))
+        t_z_coords.push(fieldMath.Fp.mul(pt.t, r))
+        t_z_coords.push(fieldMath.Fp.mul(pt.z, r))
+    }
+
+    const points = baseAffinePoints.slice(0, num_subtasks).map((x) => fieldMath.createPoint(x.x, x.y, x.t, x.z))
+
+    const start_cpu = Date.now()
+    let expected = points[0]
+    const m = BigInt(2) ** BigInt(chunk_size)
+    for (let i = 1; i < num_subtasks; i ++) {
+        expected = expected.multiply(m)
+        expected = expected.add(points[i])
+    }
+    const elapsed_cpu = Date.now() - start_cpu
+    console.log(`CPU took ${elapsed_cpu}ms to compute Horner's rule for ${num_subtasks} points`)
+
+    const device = await get_device()
+    const commandEncoder = device.createCommandEncoder()
+
+    const x_y_coords_bytes = bigints_to_u8_for_gpu(x_y_coords, num_words, word_size)
+    const t_z_coords_bytes = bigints_to_u8_for_gpu(t_z_coords, num_words, word_size)
+
+    const x_y_coords_sb = create_and_write_sb(device, x_y_coords_bytes)
+    const t_z_coords_sb = create_and_write_sb(device, t_z_coords_bytes)
+
+    const shaderCode = mustache.render(
+        horners_rule_shader,
+        {
+            word_size,
+            num_words,
+            n0,
+            p_limbs,
+            mask: BigInt(2) ** BigInt(word_size) - BigInt(1),
+            two_pow_word_size: BigInt(2) ** BigInt(word_size),
+            chunk_size,
+        },
+        {
+            structs,
+            bigint_funcs,
+            field_funcs,
+            ec_funcs,
+            curve_parameters,
+            montgomery_product_funcs,
+        },
+    )
+
+    const bindGroupLayout = create_bind_group_layout(
+        device,
+        [
+            'storage',
+            'storage',
+        ],
+    )
+    const bindGroup = create_bind_group(
+        device,
+        bindGroupLayout,
+        [ x_y_coords_sb, t_z_coords_sb ],
+    )
+
+    const start_gpu = Date.now()
+    const computePipeline = await create_compute_pipeline(
+        device,
+        [bindGroupLayout],
+        shaderCode,
+        'main',
+    )
+
+    // Horner's rule has to be run serially because each step depends on the
+    // result of the previous step
+    const num_x_workgroups = 1
+    const num_y_workgroups = 1
+
+    execute_pipeline(commandEncoder, computePipeline, bindGroup, num_x_workgroups, num_y_workgroups, 1);
+    const elapsed_gpu = Date.now() - start_gpu
+
+    const data = await read_from_gpu(
+        device,
+        commandEncoder,
+        [ x_y_coords_sb, t_z_coords_sb ]
+    )
+
+    const x_y_mont_coords_result = u8s_to_bigints(data[0], num_words, word_size)
+    const t_z_mont_coords_result = u8s_to_bigints(data[1], num_words, word_size)
+    console.log(`GPU took ${elapsed_gpu}ms to compute Horner's rule for ${num_subtasks} points (including compilation and data transfer)`)
+
+    const result = fieldMath.createPoint(
+        fieldMath.Fp.mul(x_y_mont_coords_result[0], rinv),
+        fieldMath.Fp.mul(x_y_mont_coords_result[1], rinv),
+        fieldMath.Fp.mul(t_z_mont_coords_result[0], rinv),
+        fieldMath.Fp.mul(t_z_mont_coords_result[1], rinv),
+    )
+
+    //console.log('result.isAffine():', result.toAffine())
+    //console.log('expected.isAffine():', expected.toAffine())
+    assert(are_point_arr_equal([result], [expected]))
+
+    return { x: BigInt(0), y: BigInt(0) }
+}

--- a/src/submission/wgsl/horners_rule.template.wgsl
+++ b/src/submission/wgsl/horners_rule.template.wgsl
@@ -1,0 +1,73 @@
+{{> structs }}
+{{> bigint_funcs }}
+{{> field_funcs }}
+{{> ec_funcs }}
+{{> montgomery_product_funcs }}
+{{> curve_parameters }}
+
+@group(0) @binding(0)
+var<storage, read_write> point_x_y: array<BigInt>;
+@group(0) @binding(1)
+var<storage, read_write> point_t_z: array<BigInt>;
+
+// TODO: refactor this and scalar_mul.template.wgsl as the code is repeated
+fn get_paf() -> Point {
+    var result: Point;
+    let r = get_r();
+    result.y = r;
+    result.z = r;
+    return result;
+}
+
+// Double-and-add algo adapted from the ZPrize test harness
+fn double_and_add(point: Point, scalar: u32) -> Point {
+    // Set result to the point at infinity
+    var result: Point = get_paf();
+
+    var s = scalar;
+    var temp = point;
+
+    while (s != 0u) {
+        if ((s & 1u) == 1u) {
+            result = add_points(result, temp);
+        }
+        temp = double_point(temp);
+        s = s >> 1u;
+    }
+    return result;
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    // Assume that there are 256 points or fewer
+    var id = global_id.x;
+
+    var chunk_size = {{ chunk_size }}u;
+
+    let a_x = point_x_y[0];
+    let a_y = point_x_y[1];
+    let a_t = point_t_z[0];
+    let a_z = point_t_z[1];
+
+    var result = Point(a_x, a_y, a_t, a_z);
+    let m = u32(pow(f32(2), f32(chunk_size)));
+    for (var i = 1u; i < arrayLength(&point_x_y) / 2u; i ++) {
+        let idx = id * 2u;
+        let idx1 = idx + 1u;
+        let x = point_x_y[idx];
+        let y = point_x_y[idx1];
+        let t = point_t_z[idx];
+        let z = point_t_z[idx1];
+
+        let pt = Point(x, y, t, z);
+
+        result = double_and_add(result, m);
+        result = add_points(result, pt);
+    }
+
+    point_x_y[0] = result.x;
+    point_x_y[1] = result.y;
+    point_t_z[0] = result.t;
+    point_t_z[1] = result.z;
+}

--- a/src/submission/wgsl/scalar_mul.template.wgsl
+++ b/src/submission/wgsl/scalar_mul.template.wgsl
@@ -20,7 +20,7 @@ fn get_paf() -> Point {
     return result;
 }
 
-// Double-and-add algo from the ZPrize test harness
+// Double-and-add algo adapted from the ZPrize test harness
 fn double_and_add(point: Point, scalar: u32) -> Point {
     // Set result to the point at infinity
     var result: Point = get_paf();

--- a/src/ui/AllBenchmarks.tsx
+++ b/src/ui/AllBenchmarks.tsx
@@ -28,6 +28,7 @@ import { PowersTestCase, TestCase, loadTestCase } from '../test-data/testCases';
 import { smvp } from '../submission/cuzk/smvp_wgsl';
 import { data_transfer_cost_benchmarks } from '../submission/data_transfer_cost_benchmarks'
 import { bucket_points_reduction } from '../submission/bucket_points_reduction_benchmark'
+import { horners_rule_benchmark } from '../submission/horners_rule_benchmark'
 
 export const AllBenchmarks: React.FC = () => {
   const initialDefaultInputSize = 2 ** 16
@@ -154,12 +155,12 @@ export const AllBenchmarks: React.FC = () => {
         bold={true}
       />
       <Benchmark
-        name={'Approach D'}
+        name={'Horner\s Rule'}
         disabled={disabledBenchmark}
         baseAffinePoints={baseAffineBigIntPoints}
         scalars={bigIntScalars}
         expectedResult={expectedResult}
-        msmFunc={cuzk_gpu_approach_d}
+        msmFunc={horners_rule_benchmark}
         postResult={postResult}
         bold={true}
       />
@@ -190,6 +191,16 @@ export const AllBenchmarks: React.FC = () => {
         scalars={bigIntScalars}
         expectedResult={expectedResult}
         msmFunc={data_transfer_cost_benchmarks}
+        postResult={postResult}
+        bold={true}
+      />
+      <Benchmark
+        name={'Approach D'}
+        disabled={disabledBenchmark}
+        baseAffinePoints={baseAffineBigIntPoints}
+        scalars={bigIntScalars}
+        expectedResult={expectedResult}
+        msmFunc={cuzk_gpu_approach_d}
         postResult={postResult}
         bold={true}
       />


### PR DESCRIPTION
These benchmarks indicate that we should execute Horner's rule in the CPU because the compilation time for the shader is extremely high (12s).

```
CPU took 23ms to compute Horner's rule for 16 points
GPU took 12109ms to compute Horner's rule for 16 points (including data transfer)
CPU took 32ms to compute Horner's rule for 16 points
GPU took 11ms to compute Horner's rule for 16 points (including compilation and data transfer)
CPU took 32ms to compute Horner's rule for 16 points
GPU took 19ms to compute Horner's rule for 16 points (including compilation and data transfer)
```

The high compilation time is due to the the `double_and_add` shader, which takes about 4.3s to compile if it's executed once in the shader, and about 6s to compile if executed multiple times (I tested it with cost = 1024 in `scalar_mul_benchmarks.ts`).

I'll create an issue to investigate whether it's possible to reduce the compilation time for double-and-add.